### PR TITLE
Save and restore coverdata

### DIFF
--- a/src/hoax_code.erl
+++ b/src/hoax_code.erl
@@ -54,13 +54,7 @@ restore_coverdata(ModName) ->
 
 has_coverdata_backup(ModName) ->
     Filename = coverdata_filename(ModName),
-    case file:open(Filename, [read]) of
-        {ok, D} ->
-                file:close(D),
-            true;
-        _ ->
-            false
-    end.
+    filelib:is_file(Filename).
 
 purge_and_delete(ModuleName) ->
     Sticky = code:is_sticky(ModuleName),

--- a/src/hoax_code.erl
+++ b/src/hoax_code.erl
@@ -26,12 +26,61 @@ get_callback_list(Behaviour, ModuleName) ->
         error({not_a_behaviour, Behaviour}),
     Behaviour:behaviour_info(callbacks).
 
+backup_coverdata(ModName) ->
+    case cover:is_compiled(ModName) of
+        false ->
+            ok;
+        _Other ->
+            FileName = coverdata_filename(ModName),
+            cover:export(FileName, ModName)
+    end.
+
+coverdata_filename(ModName) ->
+    %% This assumes we start and stop in the same directory.
+    {ok, D} = file:get_cwd(),
+    filename:join(D, atom_to_list(ModName) ++ ".coverdata").
+
+restore_coverdata(ModName) ->
+    File = coverdata_filename(ModName),
+    case cover:import(File) of
+        {error, {cant_open_file, File, enoent}} ->
+            ok;
+        ok ->
+            file:delete(File),
+            ok;
+        Other ->
+            Other
+    end.
+
+has_coverdata_backup(ModName) ->
+    Filename = coverdata_filename(ModName),
+    case file:open(Filename, [read]) of
+        {ok, D} ->
+                file:close(D),
+            true;
+        _ ->
+            false
+    end.
+
 purge_and_delete(ModuleName) ->
     Sticky = code:is_sticky(ModuleName),
     code:purge(ModuleName),
     code:delete(ModuleName),
     code:ensure_loaded(ModuleName),
+    case has_coverdata_backup(ModuleName) of
+        true ->
+            code:unstick_mod(ModuleName),
+            File = beam_path(ModuleName),
+            {ok, ModuleName} = cover:compile_beam(File),
+            restore_coverdata(ModuleName);
+        _ ->
+            ok
+    end,
     restore_stickiness(ModuleName, Sticky).
+
+beam_path(ModuleName) ->
+    {_, _, Filename} = code:get_object_code(ModuleName),
+    Filename.
 
 module_exists(ModuleName) ->
     case code:ensure_loaded(ModuleName) of
@@ -47,6 +96,7 @@ restore_stickiness(_, _) ->
 compile(Mod, Forms) ->
     Sticky = code:is_sticky(Mod),
     {ok, Mod, Bin} = compile:forms(Forms),
+    backup_coverdata(Mod),
     code:unstick_mod(Mod),
     code:load_binary(Mod, "", Bin),
     restore_stickiness(Mod, Sticky).


### PR DESCRIPTION
Previously using hoax to mock a module would result in coverage data
for that module (from previous tests where it was unmocked) being
lost. Now, we backup coverage data for modules that are cover-compiled
and import the coverage data when we purged the mocked module

Signed-off-by: Steven Danna <steve@chef.io>